### PR TITLE
Update method usage to support ActiveRecord 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+*gems.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.3.3
 addons:
   postgresql: '9.4'
 before_install: gem install bundler -v 1.13.6
@@ -11,3 +11,7 @@ script:
   - bundle exec rubocop
   - bundle exec rake
   - bundle exec rake build
+gemfile:
+  - Gemfile
+  - gemfiles/rails_5.0.gems
+  - gemfiles/rails_4.2.gems

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'activerecord', '~> 5.1.0'
+gem 'activesupport', '~> 5.1.0'

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ database.
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
+`rake spec` to run the tests, or `bin/test` to run tests for all supported
+ActiveRecord versions. You can also run `bin/console` for an interactive
 prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To
@@ -222,7 +223,7 @@ git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygem
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-https://github.com/mockdeep/junk_drawer. This project is intended to be a
+https://github.com/thread-pond/junk_drawer. This project is intended to be a
 safe, welcoming space for collaboration, and contributors are expected to
 adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,3 @@
+(export BUNDLE_GEMFILE=Gemfile; bundle && bundle exec rake)
+(export BUNDLE_GEMFILE=gemfiles/rails_5.0.gems; bundle && bundle exec rake spec)
+(export BUNDLE_GEMFILE=gemfiles/rails_4.2.gems; bundle && bundle exec rake spec)

--- a/gemfiles/rails_4.2.gems
+++ b/gemfiles/rails_4.2.gems
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.2.0'
+gem 'activesupport', '~> 4.2.0'

--- a/gemfiles/rails_5.0.gems
+++ b/gemfiles/rails_5.0.gems
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 5.0.0'
+gem 'activesupport', '~> 5.0.0'

--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['lobatifricha@gmail.com']
 
   spec.summary       = 'random useful Ruby utilities'
-  spec.homepage      = 'https://github.com/mockdeep/junk_drawer'
+  spec.homepage      = 'https://github.com/thread-pond/junk_drawer'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_development_dependency 'activerecord', '~> 4.2'
-  spec.add_development_dependency 'activesupport', '~> 4.2'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'

--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -66,12 +66,20 @@ module JunkDrawer
         attribute_type = columns_hash[attribute.to_s].type
         caster = POSTGRES_VALUE_CASTERS[attribute_type]
 
-        caster ? caster.type_cast_for_database(value) : value
+        caster ? serialized_value(caster, value) : value
       end
 
       sanitize_sql_array(
         ["(?, #{postgres_types.join(', ')})", object.id, *postgres_values],
       )
+    end
+
+    def serialized_value(caster, value)
+      if ::ActiveRecord::VERSION::MAJOR >= 5
+        caster.serialize(value)
+      else
+        caster.type_cast_for_database(value)
+      end
     end
   end
 end


### PR DESCRIPTION
`JunkDrawer::BulkUpdatable` uses the `ActiveRecord::ConnectionAdapters`
`::PostgreSQL::OID::Hstore` and `::Jsonb` `#type_cast_for_database`
method, which was renamed to `serialize` in ActiveRecord 5. This adds
logic to use the appropriate method based on ActiveRecord version.

It also creates separate gem files for each supported ActiveRecord
version for testing.