### PR TITLE
Create user and test database in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+createuser -s -r postgres
+createdb junk_drawer_test -U postgres
+
 bundle install
 
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
When setting up the dev environment, running `rake test` requires a
`postgres` user and `junk_drawer_test` database, so this adds them.