### PR TITLE
Bugs: pass block down to Callable instance method

### DIFF
--- a/lib/junk_drawer/callable.rb
+++ b/lib/junk_drawer/callable.rb
@@ -19,8 +19,8 @@ module JunkDrawer
     # an instance. It also causes an error to be raised if a public instance
     # method is defined with a name other than `call`
     module ClassMethods
-      def call(*args)
-        new.(*args)
+      def call(*args, &block)
+        new.(*args, &block)
       end
 
       def to_proc

--- a/spec/junk_drawer/callable_spec.rb
+++ b/spec/junk_drawer/callable_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe JunkDrawer::Callable do
     expect(MyCallableClass.('what', who: 'cares')).to eq expected
   end
 
+  it 'passes through a block to the instance method' do
+    class MyCallableClass
+      include JunkDrawer::Callable
+      def call
+        yield 'foo block content'
+      end
+    end
+
+    actual = nil
+    MyCallableClass.() { |result| actual = result }
+    expect(actual).to eq 'foo block content'
+  end
+
   it 'throws an error when call method is not defined' do
     class MyCallableClass
       include JunkDrawer::Callable


### PR DESCRIPTION
This fixes an issue where using the class level `call` method cannot
be used with a block.