### PR TITLE
BulkUpdatable: refactor test to loop through types

### DIFF
--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
+  DATA_TYPES = %i[
+    string
+    boolean
+    hstore
+    datetime
+    jsonb
+  ].freeze
+
   with_model :BulkUpdatableModel do
     table do |t|
-      t.string :thing
-      t.boolean :bool_thing
-      t.hstore :data_thing, default: {}, null: false
-      t.datetime :some_time
-      t.jsonb :data_thing, default: {}, null: false
-      t.datetime :updated_at
+      DATA_TYPES.each do |data_type|
+        t.public_send(data_type, "#{data_type}_value")
+      end
+
+      t.datetime :updated_at, null: false
     end
 
     model do
@@ -18,25 +25,25 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
 
   let(:models) do
     [
-      BulkUpdatableModel.create!(thing: ''),
-      BulkUpdatableModel.create!(thing: ''),
+      BulkUpdatableModel.create!(string_value: ''),
+      BulkUpdatableModel.create!(string_value: ''),
     ]
   end
 
   it 'updates the attribute on all the models' do
     models.each_with_index do |model, index|
-      model.thing = "thing_#{index}"
+      model.string_value = "thing_#{index}"
     end
 
     BulkUpdatableModel.bulk_update(models)
     models.each(&:reload)
 
-    expect(models[0].thing).to eq 'thing_0'
-    expect(models[1].thing).to eq 'thing_1'
+    expect(models[0].string_value).to eq 'thing_0'
+    expect(models[1].string_value).to eq 'thing_1'
   end
 
   it 'only updates the models with changes' do
-    models.first.thing = 'changed attr!'
+    models.first.string_value = 'changed attr!'
 
     expect do
       BulkUpdatableModel.bulk_update(models)
@@ -47,7 +54,7 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
   it 'updates the updated_at on the models' do
     expect do
       models.each_with_index do |model, index|
-        model.thing = "thing_#{index}"
+        model.string_value = "thing_#{index}"
       end
 
       BulkUpdatableModel.bulk_update(models)
@@ -63,65 +70,65 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
 
   it 'works for hstore datatypes' do
     models.each_with_index do |model, index|
-      model.data_thing["key_#{index}"] = "thing_data_#{index}"
+      model.hstore_value = { "key_#{index}": "thing_data_#{index}" }
     end
 
     BulkUpdatableModel.bulk_update(models)
     models.each(&:reload)
 
-    expect(models[0].data_thing).to eq('key_0' => 'thing_data_0')
-    expect(models[1].data_thing).to eq('key_1' => 'thing_data_1')
+    expect(models[0].hstore_value).to eq('key_0' => 'thing_data_0')
+    expect(models[1].hstore_value).to eq('key_1' => 'thing_data_1')
   end
 
   it 'works for jsonb datatypes' do
     models.each_with_index do |model, index|
-      model.data_thing = { key: index }
+      model.jsonb_value = { key: index }
     end
 
     BulkUpdatableModel.bulk_update(models)
     models.each(&:reload)
 
-    expect(models[0].data_thing).to eq('key' => 0)
-    expect(models[1].data_thing).to eq('key' => 1)
+    expect(models[0].jsonb_value).to eq('key' => 0)
+    expect(models[1].jsonb_value).to eq('key' => 1)
   end
 
   it 'works for boolean datatypes' do
-    models.first.bool_thing = true
-    models.last.bool_thing = false
+    models.first.boolean_value = true
+    models.last.boolean_value = false
 
     BulkUpdatableModel.bulk_update(models)
     models.each(&:reload)
 
-    expect(models.first.bool_thing).to be true
-    expect(models.last.bool_thing).to be false
+    expect(models.first.boolean_value).to be true
+    expect(models.last.boolean_value).to be false
   end
 
   it 'works for datetime datatypes' do
     now = Time.zone.now.round
     before = 3.days.ago.round
 
-    models.first.some_time = now
-    models.last.some_time = before
+    models.first.datetime_value = now
+    models.last.datetime_value = before
 
     BulkUpdatableModel.bulk_update(models)
     models.each(&:reload)
 
-    expect(models.first.some_time.round).to eq now
-    expect(models.last.some_time.round).to eq before
+    expect(models.first.datetime_value.round).to eq now
+    expect(models.last.datetime_value.round).to eq before
   end
 
   it 'can bulk update multiple columns at once' do
-    models.first.bool_thing = true
-    models.first.thing = 'weeehooo'
-    models.last.bool_thing = false
-    models.last.thing = 'plop'
+    models.first.boolean_value = true
+    models.first.string_value = 'weeehooo'
+    models.last.boolean_value = false
+    models.last.string_value = 'plop'
 
     BulkUpdatableModel.bulk_update(models)
     models.each(&:reload)
 
-    expect(models.first.bool_thing).to be true
-    expect(models.first.thing).to eq 'weeehooo'
-    expect(models.last.bool_thing).to be false
-    expect(models.last.thing).to eq 'plop'
+    expect(models.first.boolean_value).to be true
+    expect(models.first.string_value).to eq 'weeehooo'
+    expect(models.last.boolean_value).to be false
+    expect(models.last.string_value).to eq 'plop'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ ActiveRecord::Base.establish_connection(
   database: 'junk_drawer_test',
   host: 'localhost',
 )
+ActiveRecord::Base.connection.execute('CREATE EXTENSION IF NOT EXISTS hstore;')
 
 RSpec.configure do |config|
   config.order = :random


### PR DESCRIPTION
I'm planning on adding a bunch more types to the tests, so wanted to
make it easier to add them without needing to come up with witty names
for each.

A side effect of this change is that I discovered that `hstore` wasn't
being tested because it was getting overridden by the `jsonb` column
with the same name. I added a line to `spec_helper.rb` to create the
`hstore` extension if it doesn't already exist, being that it didn't
exist for me in the test database at first.