### PR TITLE
BulkUpdatable: extract specs to shared examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Exclude:
     - junk_drawer.gemspec
-    - spec/**/*_spec.rb
+    - spec/**/*
 
 RSpec/ExampleLength:
   Enabled: false

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -23,12 +23,7 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
     end
   end
 
-  let(:models) do
-    [
-      BulkUpdatableModel.create!(string_value: ''),
-      BulkUpdatableModel.create!(string_value: ''),
-    ]
-  end
+  let(:models) { [BulkUpdatableModel.create!, BulkUpdatableModel.create!] }
 
   it 'updates the attribute on all the models' do
     models.each_with_index do |model, index|
@@ -68,55 +63,6 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
     end.not_to raise_error
   end
 
-  it 'works for hstore datatypes' do
-    models.each_with_index do |model, index|
-      model.hstore_value = { "key_#{index}": "thing_data_#{index}" }
-    end
-
-    BulkUpdatableModel.bulk_update(models)
-    models.each(&:reload)
-
-    expect(models[0].hstore_value).to eq('key_0' => 'thing_data_0')
-    expect(models[1].hstore_value).to eq('key_1' => 'thing_data_1')
-  end
-
-  it 'works for jsonb datatypes' do
-    models.each_with_index do |model, index|
-      model.jsonb_value = { key: index }
-    end
-
-    BulkUpdatableModel.bulk_update(models)
-    models.each(&:reload)
-
-    expect(models[0].jsonb_value).to eq('key' => 0)
-    expect(models[1].jsonb_value).to eq('key' => 1)
-  end
-
-  it 'works for boolean datatypes' do
-    models.first.boolean_value = true
-    models.last.boolean_value = false
-
-    BulkUpdatableModel.bulk_update(models)
-    models.each(&:reload)
-
-    expect(models.first.boolean_value).to be true
-    expect(models.last.boolean_value).to be false
-  end
-
-  it 'works for datetime datatypes' do
-    now = Time.zone.now.round
-    before = 3.days.ago.round
-
-    models.first.datetime_value = now
-    models.last.datetime_value = before
-
-    BulkUpdatableModel.bulk_update(models)
-    models.each(&:reload)
-
-    expect(models.first.datetime_value.round).to eq now
-    expect(models.last.datetime_value.round).to eq before
-  end
-
   it 'can bulk update multiple columns at once' do
     models.first.boolean_value = true
     models.first.string_value = 'weeehooo'
@@ -130,5 +76,9 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
     expect(models.first.string_value).to eq 'weeehooo'
     expect(models.last.boolean_value).to be false
     expect(models.last.string_value).to eq 'plop'
+  end
+
+  DATA_TYPES.each do |type|
+    it_behaves_like 'bulk updatable type', type
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'with_model'
 
 require_relative '../lib/junk_drawer/rails'
-require_relative 'support/invoke_matcher'
+Dir['./spec/support/**/*.rb'].each { |file_path| require file_path }
 
 Time.zone = 'Eastern Time (US & Canada)'
 

--- a/spec/support/shared_examples/bulk_updatable_type.rb
+++ b/spec/support/shared_examples/bulk_updatable_type.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+GENERATORS = {
+  string: ->(index) { "wat_#{index}" },
+  boolean: ->(index) { index.even? },
+  hstore: ->(index) { { "foo_#{index}" => "bar_#{index}" } },
+  datetime: ->(index) { Time.zone.now.in_time_zone('UTC').round - index.days },
+  jsonb: ->(index) { { "bee_#{index}" => "bizzle_#{index}" } },
+}.freeze
+
+RSpec.shared_examples 'bulk updatable type' do |type|
+  let(:getter_name) { "#{type}_value" }
+  let(:setter_name) { "#{type}_value=" }
+  let(:type) { type }
+
+  def model_values(models)
+    BulkUpdatableModel.where(id: models.map(&:id)).pluck(getter_name)
+  end
+
+  def generate_values(models, seed: 1)
+    models.each_with_index.map do |model, index|
+      value = GENERATORS.fetch(type).(index * seed)
+      model.public_send(setter_name, value)
+    end
+  end
+
+  it "can update records from null to value for type: #{type}" do
+    values = generate_values(models)
+
+    expect do
+      BulkUpdatableModel.bulk_update(models)
+    end.to change { model_values(models) }.from([nil, nil]).to(values)
+  end
+
+  it "can update records from value to new value for type: #{type}" do
+    old_values = generate_values(models)
+    models.each(&:save!)
+    new_values = generate_values(models, seed: 2)
+
+    expect do
+      BulkUpdatableModel.bulk_update(models)
+    end.to change { model_values(models) }.from(old_values).to(new_values)
+  end
+
+  it "can update records from value to null for type: #{type}" do
+    old_values = generate_values(models)
+    models.each(&:save!)
+    models.each { |model| model.public_send(setter_name, nil) }
+
+    expect do
+      BulkUpdatableModel.bulk_update(models)
+    end.to change { model_values(models) }.from(old_values).to([nil, nil])
+  end
+end


### PR DESCRIPTION
I'm going to be adding a lot more types to be tested against here, so
wanted to make them a little more generic. This adds a new set of shared
examples and runs them against each type. I added a `GENERATORS` hash to
generate data for each type and a couple of helper methods in the test.
One weird thing is that in order to access `type` in the methods, I
needed to set it in a `let`, otherwise it would throw a `NoMethodError`.