### PR TITLE
BulkUpdatable: add support for a host of new types

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -8,15 +8,23 @@ module JunkDrawer
   # module to allow bulk updates for `ActiveRecord` models
   module BulkUpdatable
     ATTRIBUTE_TYPE_TO_POSTGRES_CAST = {
-      datetime: '::timestamp',
-      hstore: '::hstore',
       boolean: '::boolean',
+      date: '::date',
+      datetime: '::timestamp',
+      float: '::float',
+      hstore: '::hstore',
+      integer: '::int',
+      json: '::json',
       jsonb: '::jsonb',
+      decimal: '::decimal',
+      time: '::time',
+      uuid: '::uuid',
     }.freeze
 
     POSTGRES_VALUE_CASTERS = {
       hstore: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore.new,
       jsonb: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb.new,
+      json: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json.new,
     }.freeze
 
     def bulk_update(objects)

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -2,11 +2,19 @@
 
 RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
   DATA_TYPES = %i[
-    string
     boolean
-    hstore
+    date
     datetime
+    decimal
+    float
+    hstore
+    integer
+    json
     jsonb
+    string
+    text
+    timestamp
+    uuid
   ].freeze
 
   with_model :BulkUpdatableModel do

--- a/spec/support/shared_examples/bulk_updatable_type.rb
+++ b/spec/support/shared_examples/bulk_updatable_type.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 GENERATORS = {
-  string: ->(index) { "wat_#{index}" },
   boolean: ->(index) { index.even? },
-  hstore: ->(index) { { "foo_#{index}" => "bar_#{index}" } },
+  date: ->(index) { Time.zone.now.to_date - index.days },
   datetime: ->(index) { Time.zone.now.in_time_zone('UTC').round - index.days },
+  decimal: ->(index) { index * 2.3 },
+  float: ->(index) { index * 2.3 },
+  hstore: ->(index) { { "foo_#{index}" => "bar_#{index}" } },
+  integer: ->(index) { index + 5 },
+  json: ->(index) { { "boo_#{index}" => "bazzle_#{index}" } },
   jsonb: ->(index) { { "bee_#{index}" => "bizzle_#{index}" } },
+  string: ->(index) { "wat_#{index}" },
+  text: ->(index) { "text_#{index}" },
+  timestamp: ->(index) { Time.zone.now.in_time_zone('UTC').round - index.days },
+  uuid: ->(index) { "616f5839-731e-404d-869b-d0489438632#{index}" },
 }.freeze
 
 RSpec.shared_examples 'bulk updatable type' do |type|


### PR DESCRIPTION
This is probably all of the major simple types we might want to cover
for now, however we still need to handle array type columns, such as
integer or string arrays. This will come in a followup.

**Notes**

- I tried to implement `bigint` and `time` types, but it looks like
  those may be a little more complicated. Probably fine for now, but
  Rails now defaults primary key columns to `bigint`. This will only
  become a problem when we hit a primary key that is greater than
  2,147,483,647, so we've got time to handle that.
- Likewise, there are a whole bunch of other column types we might at
  some point want to support, but this seemed like it covered the vast
  majority of use cases.

https://www.postgresql.org/docs/10/static/datatype-numeric.html
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L75-L116