### PR TITLE
BulkUpdatable: switch to using fetch for cast

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -17,6 +17,8 @@ module JunkDrawer
       json: '::json',
       jsonb: '::jsonb',
       decimal: '::decimal',
+      string: '::text',
+      text: '::text',
       time: '::time',
       uuid: '::uuid',
     }.freeze
@@ -66,7 +68,7 @@ module JunkDrawer
     def sanitized_values(object, attributes)
       postgres_types = attributes.map do |attribute|
         attribute_type = columns_hash[attribute.to_s].type
-        "?#{ATTRIBUTE_TYPE_TO_POSTGRES_CAST[attribute_type]}"
+        "?#{ATTRIBUTE_TYPE_TO_POSTGRES_CAST.fetch(attribute_type)}"
       end
 
       postgres_values = attributes.map do |attribute|


### PR DESCRIPTION
While `string` and `text` are basically the default Postgres assumes, I
think it'll be better to have this be explicit, especially since all
other types are in the map. This will also help accommodate array type
columns, since we need to cast using `::string[]` or `::int[]` for
those.