### PR TITLE
BulkUpdatable: `squish` SQL query

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -51,7 +51,7 @@ module JunkDrawer
         "#{quoted_column_name} = tmp_table.#{quoted_column_name}"
       end.join(', ')
 
-      <<-SQL
+      <<-SQL.squish
         UPDATE #{table_name}
         SET #{assignment_query}
         FROM (VALUES #{object_values}) AS tmp_table(id, #{attributes.join(', ')})


### PR DESCRIPTION
It's nice to have it multi-line for code readability, but squishing it
all down to one line will be a little more log friendly, and also
consistent with the rest of the really long queries that get generated
in Rails, which are always one line.