### PR TITLE
Tools: add `pry-byebug`

### DIFF
--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
   spec.add_development_dependency 'pg', '~> 0.20'
   spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'pry-byebug', '~> 3.6.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.48.1'


### PR DESCRIPTION
`pry-byebug` adds debugger commands to `pry` so we can use things like
`next`, `skip`, `continue`, etc.

https://github.com/deivid-rodriguez/pry-byebug

This is not included by default, so in order to use this during
development, we need to add `require 'pry-byebug'` to the top of files.