### PR TITLE
BulkUpdatable: remove manual type cast map

### DIFF
--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -2,20 +2,45 @@
 
 RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
   DATA_TYPES = %i[
+    bigint
+    bit
     boolean
     date
     datetime
     decimal
     float
     hstore
+    inet
     integer
     json
     jsonb
+    macaddr
     string
     text
+    time
     timestamp
     uuid
   ].freeze
+
+  ## Types we're missing:
+
+  ### not supported by ActiveRecord
+  # char
+  # real
+  # smallint
+  # timestampz
+  # varchar
+
+  ### probably not important
+  # box
+  # interval
+  # line
+  # lseg
+  # money
+  # path
+  # point
+  # polygon
+  # range
 
   with_model :BulkUpdatableModel do
     table do |t|

--- a/spec/support/shared_examples/bulk_updatable_type.rb
+++ b/spec/support/shared_examples/bulk_updatable_type.rb
@@ -1,18 +1,27 @@
 # frozen_string_literal: true
 
+def now
+  Time.zone.now.in_time_zone('UTC').round
+end
+
 GENERATORS = {
+  bigint: ->(index) { index + 10 },
+  bit: ->(index) { (index % 2).to_s },
   boolean: ->(index) { index.even? },
-  date: ->(index) { Time.zone.now.to_date - index.days },
-  datetime: ->(index) { Time.zone.now.in_time_zone('UTC').round - index.days },
+  date: ->(index) { now.to_date - index.days },
+  datetime: ->(index) { now - index.days },
   decimal: ->(index) { index * 2.3 },
   float: ->(index) { index * 2.3 },
   hstore: ->(index) { { "foo_#{index}" => "bar_#{index}" } },
+  inet: ->(index) { IPAddr.new("192.168.0.#{index}") },
   integer: ->(index) { index + 5 },
   json: ->(index) { { "boo_#{index}" => "bazzle_#{index}" } },
   jsonb: ->(index) { { "bee_#{index}" => "bizzle_#{index}" } },
+  macaddr: ->(index) { "08:00:2b:01:02:0#{index}" },
   string: ->(index) { "wat_#{index}" },
   text: ->(index) { "text_#{index}" },
-  timestamp: ->(index) { Time.zone.now.in_time_zone('UTC').round - index.days },
+  time: ->(index) { (now - index.hours).change(year: 2000, month: 1, day: 1) },
+  timestamp: ->(index) { now - index.days },
   uuid: ->(index) { "616f5839-731e-404d-869b-d0489438632#{index}" },
 }.freeze
 


### PR DESCRIPTION
So it turns out we can apparently use `column.sql_type` for the cast.
How cool is that? I also added a few more types to the tests, and a list
of other types we might want to test at some point. Not sure how
important it is, though, to test all of them, being that it seems like
the generalized `sql_type` might just cover our butts on all types.