### PR TITLE
BulkUpdatable: add tests for `hstore_accessor`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 
 gem 'activerecord', '~> 5.1.0'
 gem 'activesupport', '~> 5.1.0'
+gem 'hstore_accessor', '~> 1.1.1'

--- a/gemfiles/rails_4.2.gems
+++ b/gemfiles/rails_4.2.gems
@@ -6,3 +6,4 @@ gemspec path: '../'
 
 gem 'activerecord', '~> 4.2.0'
 gem 'activesupport', '~> 4.2.0'
+gem 'hstore_accessor', '~> 1.1.1'

--- a/gemfiles/rails_5.0.gems
+++ b/gemfiles/rails_5.0.gems
@@ -6,3 +6,4 @@ gemspec path: '../'
 
 gem 'activerecord', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.0'
+gem 'hstore_accessor', '~> 1.1.1'

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'hstore_accessor'
+
 RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
   DATA_TYPES = %i[
     bigint
@@ -58,11 +60,14 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
         t.public_send(data_type, "#{data_type}_array_value", array: true)
       end
 
+      t.hstore :hstore_accessor_value
       t.datetime :updated_at, null: false
     end
 
     model do
       extend JunkDrawer::BulkUpdatable
+
+      hstore_accessor :hstore_accessor_value, nested_hstore_value: :string
     end
   end
 
@@ -128,4 +133,6 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
   ARRAY_TYPES.each do |type|
     it_behaves_like 'bulk updatable type', "#{type}_array".to_sym
   end
+
+  it_behaves_like 'bulk updatable type', :nested_hstore
 end

--- a/spec/support/shared_examples/bulk_updatable_type.rb
+++ b/spec/support/shared_examples/bulk_updatable_type.rb
@@ -19,6 +19,7 @@ GENERATORS = {
   json: ->(index) { { "boo_#{index}" => "bazzle_#{index}" } },
   jsonb: ->(index) { { "bee_#{index}" => "bizzle_#{index}" } },
   macaddr: ->(index) { "08:00:2b:01:02:0#{index}" },
+  nested_hstore: ->(index) { "hstore_#{index}" },
   string: ->(index) { "wat_#{index}" },
   string_array: ->(index) { Array.new(index) { |i| "string_#{i}" } },
   text: ->(index) { "text_#{index}" },
@@ -29,18 +30,19 @@ GENERATORS = {
 }.freeze
 
 RSpec.shared_examples 'bulk updatable type' do |type|
-  let(:getter_name) { "#{type}_value" }
-  let(:setter_name) { "#{type}_value=" }
+  let(:getter_name) { "#{type}_value".to_sym }
+  let(:setter_name) { "#{type}_value=".to_sym }
   let(:type) { type }
 
   def model_values(models)
-    BulkUpdatableModel.where(id: models.map(&:id)).pluck(getter_name)
+    BulkUpdatableModel.where(id: models.map(&:id)).map(&getter_name)
   end
 
   def generate_values(models, seed: 1)
     models.each_with_index.map do |model, index|
       value = GENERATORS.fetch(type).(index * seed)
       model.public_send(setter_name, value)
+      value
     end
   end
 


### PR DESCRIPTION
Turns out `hstore_accessor` works out of the box, but this adds tests to
verify it. No such luck with `jsonb_accessor`, so support for that will
be forthcoming.

I had to make a couple of adjustments to the tests:

- Changed `pluck` to `map`. Since `hstore_accessor` values are nested,
  they don't correspond to a database column which can be `pluck`ed.
- Adding the `&` in front of `getter_name` means it needs to be a
  symbol, since the `to_proc` operator doesn't work on strings.
- Added `value` to be returned from the generated values. I think this
  is maybe a little more clear anyway, but this was actually really
  interesting behavior. One thing about ruby is that when you call a
  setter it *always* returns the thing that was passed in, regardless of
  return value. Except if you use `send`:

  ```ruby
  class Foo
    def my_thing=(whatever)
      'who cares!?'
    end
  end

  Foo.new.my_thing = 'wat'
  # => "wat"

  Foo.new.send('my_thing=', 'wat')
  # => "who cares!?"
  ```