### PR TITLE
BulkUpdatable: clear changes after query

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -14,6 +14,7 @@ module JunkDrawer
       changed_attributes = extract_changed_attributes(objects)
       query = build_query_for(objects, changed_attributes)
       connection.execute(query)
+      objects.each(&:clear_changes_information)
     end
 
   private

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -160,4 +160,17 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
   it_behaves_like 'bulk updatable type', :nested_hstore
   it_behaves_like 'bulk updatable type', :nested_jsonb
   it_behaves_like 'bulk updatable type', :nested_jsonb_array
+
+  it 'clears change information on records after save' do
+    models.first.boolean_value = true
+    models.first.string_value = 'weeehooo'
+    models.last.boolean_value = false
+    models.last.string_value = 'plop'
+
+    expect(models.all?(&:changed?)).to be true
+
+    BulkUpdatableModel.bulk_update(models)
+
+    expect(models.any?(&:changed?)).to be false
+  end
 end


### PR DESCRIPTION
Pretty simple. When we call `#save` on a record, ActiveRecord clears
changes, so it makes sense to do the same when bulk updating. One thing
of note is that `clear_changes_information` clobbers all change
information. `#save` moves `changes` to `previous_changes`, which ought
to be possible via the `#changes_applied` method, but there appears to
be some weird caching going on preventing this from working, so we went
with `#clear_changes_information`, which clears both `changes` and
`previous_changes`. This may be something we can revisit in Rails 5.2 or
later, as it appears this logic has shifted quite a bit.

Rails 5.1:
https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/attribute_methods/dirty.rb#L71-L83

Rails 5.2, no change tracking methods:
https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/attribute_methods/dirty.rb