### PR TITLE
Bug: Fix spaces and newlines getting stripped form query

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -58,12 +58,11 @@ module JunkDrawer
         "#{quoted_column_name} = tmp_table.#{quoted_column_name}"
       end.join(', ')
 
-      <<-SQL.squish
-        UPDATE #{table_name}
-        SET #{assignment_query}
-        FROM (VALUES #{object_values}) AS tmp_table(id, #{attributes.join(', ')})
-        WHERE #{table_name}.id = tmp_table.id
-      SQL
+      "UPDATE #{table_name} " \
+      "SET #{assignment_query} " \
+      "FROM (VALUES #{object_values}) " \
+      "AS tmp_table(id, #{attributes.join(', ')}) " \
+      "WHERE #{table_name}.id = tmp_table.id"
     end
 
     def sanitized_values(object, attributes)

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -117,6 +117,17 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
       .and not_change { models.last.updated_at }
   end
 
+  it 'properly updates when strings have multiple spaces' do
+    models.first.string_value = 'something  with  two  spaces'
+    models.second.string_value = "newline \n thing"
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models[0].string_value).to eq 'something  with  two  spaces'
+    expect(models[1].string_value).to eq "newline \n thing"
+  end
+
   it 'updates the updated_at on the models' do
     expect do
       models.each_with_index do |model, index|


### PR DESCRIPTION
**What**

- Changes the `squish` to be a multiline string instead of a block string
in BulkUpdatable so that the newlines and double spaces will not get
stripped on the passed in attributes.

**Why**

I noticed that BulkUpdateable was saving records to the database without
both spaces in the values. Additionally, newlines were getting stripped.

The `squish` was introduced for logging purposes in this PR:
https://github.com/thread-pond/junk_drawer/pull/12