### PR TITLE
Cacheable: Run after_commit callbacks on bulk_update

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -15,7 +15,10 @@ module JunkDrawer
       changed_attributes = extract_changed_attributes(unique_objects)
       query = build_query_for(unique_objects, changed_attributes)
       connection.execute(query)
-      objects.each(&:clear_changes_information)
+      objects.each do |object|
+        object.committed! # run ActiveRecord `after_commit` hooks
+        object.clear_changes_information
+      end
     end
 
   private


### PR DESCRIPTION
**what**
adds a call to [`ActiveRecord::Transactions#committed!`](https://github.com/rails/rails/blob/fc5dd0b85189811062c85520fd70de8389b55aeb/activerecord/lib/active_record/transactions.rb#L338-L351) on each object
that's been bulk-updated. This will run any `after_commit` hooks that
are defined on the model. Currently in synchroform (on master), the only
`after_commit` hooks we have defined on our models are [the ones added by carrierwave](https://github.com/carrierwaveuploader/carrierwave/blob/c45699c318ca895f89fa3304204e48b5f1c411f1/lib/carrierwave/orm/activerecord.rb#L57-L61).

**why**
We're currently creating a module called `Cacheable`, which will cache
records on `find` and `find_by` when the module is included and
configured in the record's model class. `Cacheable` invalidates a
record's cache `after_commit`. For most methods that commit but don't
run callbacks (e.g. `update_attribute`, `update_all`, etc.), we've
overridden the method to call `super` and then invalidate the cache for
that record. In the case of `bulk_update`, though, we decided to update
`BulkUpdatable` to run `after_commit` callbacks because we want to move
towards running callbacks in `BulkUpdatable` in general.