### PR TITLE
Upgrades: fix deprecations in Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 addons:
   postgresql: '9.4'
-before_install: gem install bundler -v 1.13.6
+before_install: gem install bundler -v 2.0.2
 before_script:
   - createdb junk_drawer_test -U postgres
 script:

--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'

--- a/lib/junk_drawer/callable.rb
+++ b/lib/junk_drawer/callable.rb
@@ -19,8 +19,8 @@ module JunkDrawer
     # an instance. It also causes an error to be raised if a public instance
     # method is defined with a name other than `call`
     module ClassMethods
-      def call(*args, &block)
-        new.(*args, &block)
+      def call(*args, **kwargs, &block)
+        new.(*args, **kwargs, &block)
       end
 
       def to_proc

--- a/spec/junk_drawer/notifier/honeybadger_strategy_spec.rb
+++ b/spec/junk_drawer/notifier/honeybadger_strategy_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe JunkDrawer::Notifier::HoneybadgerStrategy, '#call' do
 
     expected_args = [JunkDrawer::NotifierError.new(message), context: context]
     expect do
-      strategy.(message, context)
+      strategy.(message, **context)
     end.to invoke(:notify).on(Honeybadger).with(*expected_args)
   end
 
@@ -27,7 +27,7 @@ RSpec.describe JunkDrawer::Notifier::HoneybadgerStrategy, '#call' do
     context = { goober: 'gutz' }
 
     expect do
-      strategy.(error, context)
+      strategy.(error, **context)
     end.to invoke(:notify).on(Honeybadger).with(error, context: context)
   end
 end


### PR DESCRIPTION
Ruby complains about implicitly passing a hash as keyword arguments. If
we want to pass in a hash that will be slurped up on the other side with
`**`, then we need to splat it out with `**` when we're calling it. This
fixes deprecation warnings to this effect, though the fixes should be
backwards compatible.

**Notes**

* I removed the `bundler` version from the `gemspec` file. I don't think
  it makes any sense to have in there.
* I added more ruby versions to the `.travis.yml` section. We can
  probably deprecate some of the older versions we're testing against.
