### PR TITLE
bump version

### DIFF
--- a/lib/junk_drawer/version.rb
+++ b/lib/junk_drawer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JunkDrawer
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end


### PR DESCRIPTION
This will release the update to fix deprecation warnings for Ruby 2.7.
