### PR TITLE
Upgrades: fix keyword arguments across versions

### DIFF
--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
+  spec.add_runtime_dependency 'ruby2_keywords', '~> 0.0.2'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'

--- a/lib/junk_drawer/callable.rb
+++ b/lib/junk_drawer/callable.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ruby2_keywords'
+
 module JunkDrawer
   # error to be thrown by Callable
   class CallableError < StandardError
@@ -19,8 +21,8 @@ module JunkDrawer
     # an instance. It also causes an error to be raised if a public instance
     # method is defined with a name other than `call`
     module ClassMethods
-      def call(*args, **kwargs, &block)
-        new.(*args, **kwargs, &block)
+      ruby2_keywords def call(*args, &block)
+        new.(*args, &block)
       end
 
       def to_proc

--- a/spec/junk_drawer/callable_spec.rb
+++ b/spec/junk_drawer/callable_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe JunkDrawer::Callable do
     expect(MyCallableClass.('what', who: 'cares')).to eq expected
   end
 
+  it 'handles default arguments' do
+    class MyCallableClass
+      include JunkDrawer::Callable
+      def call(one_arg = 'foo')
+        "calling in, #{one_arg}"
+      end
+    end
+
+    expected = 'calling in, foo'
+    expect(MyCallableClass.()).to eq expected
+  end
+
   it 'passes through a block to the instance method' do
     class MyCallableClass
       include JunkDrawer::Callable


### PR DESCRIPTION
Fixes #28. Ruby 2.6 splat arguments behave differently from Ruby 2.7
splat arguments which behave (slightly) differently from Ruby 3.0 splat
arguments. It turns out it's hard to handle all of them gracefully, but
thankfully a little gem called [`ruby2_keywords`][rbkw] is provided by
Ruby core for us to transition smoothly. For Ruby versions 2.6 and
earlier, it is a no-op. For Ruby versions 2.7 and up, the method is
already defined in core Ruby, in which cases the gem does nothing. The
core version internally translates the arguments to Ruby 3 style keyword
arguments. You can read all about the complexities [here][blog]. There
are several other suggested ways of handling the issue, but this seemed
to be the cleanest. Once Ruby <= 2.6 support is dropped, this should be
able to be removed.

[rbkw]: https://github.com/ruby/ruby2_keywords
[blog]: https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html
