### PR TITLE
Notifier: add ability to configure with arbitrary callable strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+vendor/

--- a/README.md
+++ b/README.md
@@ -27,9 +27,18 @@ gem 'junk_drawer', require: 'junk_drawer/rails'
 
 ### Contents
 
-- [JunkDrawer::Callable](#junkdrawercallable)
-- [JunkDrawer::Notifier](#junkdrawernotifier)
-- [JunkDrawer::BulkUpdatable](#junkdrawerbulkupdatable)
+- [JunkDrawer](#junkdrawer)
+  - [Installation](#installation)
+    - [Contents](#contents)
+  - [Usage](#usage)
+    - [JunkDrawer::Callable](#junkdrawercallable)
+    - [JunkDrawer::Notifier](#junkdrawernotifier)
+  - [Rails](#rails)
+    - [JunkDrawer::BulkUpdatable](#junkdrawerbulkupdatable)
+      - [Caveats](#caveats)
+  - [Development](#development)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Usage
 
@@ -128,6 +137,28 @@ your selected strategy. The strategies available are as follows:
 
 3) `:null` is a noop. If you want to disable notifications temporarily, you can
   configure the strategy to `:null`.
+
+4) To create your own custom notifier, configure `JunkDrawer::Notifier` with
+  a callable object as the strategy.
+
+```ruby
+class MyNotifier
+  include JunkDrawer::Callable
+
+  def call(*args)
+    SomeMonitoringService.notify(*args)
+  end
+end
+
+JunkDrawer::Notifier.strategy = MyNotifier
+```
+
+```ruby
+JunkDrawer::Notifier.strategy = ->(*args) {
+  MonitoringServiceA.notify(*args)
+  MonitoringServiceB.notify(*args)
+}
+```
 
 If you're using Rails, you may want to configure `Notifier` based on the
 environment, so in your `config/environments/development.rb` you might have:

--- a/lib/junk_drawer/notifier.rb
+++ b/lib/junk_drawer/notifier.rb
@@ -12,7 +12,12 @@ module JunkDrawer
 
     class << self
 
-      attr_accessor :strategy
+      attr_reader :strategy
+
+      def strategy=(strategy)
+        @strategy =
+          strategy.is_a?(Symbol) ? STRATEGIES.fetch(strategy) : strategy
+      end
 
     end
 
@@ -23,13 +28,7 @@ module JunkDrawer
     }.freeze
 
     def call(*args)
-      strategy.(*args)
-    end
-
-  private
-
-    def strategy
-      STRATEGIES.fetch(self.class.strategy)
+      self.class.strategy.(*args)
     end
 
   end

--- a/spec/junk_drawer/notifier_spec.rb
+++ b/spec/junk_drawer/notifier_spec.rb
@@ -3,12 +3,24 @@
 RSpec.describe JunkDrawer::Notifier, '#call' do
   let(:notifier) { described_class.new }
 
-  it 'calls the configured notifier with the given arguments' do
+  after { JunkDrawer::Notifier.strategy = :null }
+
+  it 'calls the configured pre-defined notifier with the given arguments' do
     JunkDrawer::Notifier.strategy = :raise
     strategy = JunkDrawer::Notifier::RaiseStrategy
-    expect do
-      notifier.('foo', 'bar', 'butts')
-    end.to invoke(:call).on(strategy).with('foo', 'bar', 'butts')
-    JunkDrawer::Notifier.strategy = :nil
+    expect { notifier.('foo', 'bar', 'butts') }
+      .to invoke(:call).on(strategy).with('foo', 'bar', 'butts')
+  end
+
+  it 'calls the configured callable notifier with the given arguments' do
+    fake_notifier = ->(thing_1, thing_2) { "#{thing_1}#{thing_2}" }
+    JunkDrawer::Notifier.strategy = fake_notifier
+
+    expect(notifier.('juan', 'deux')).to eq 'juandeux'
+  end
+
+  it 'raises an error when configured with a non-existing notifier' do
+    expect { JunkDrawer::Notifier.strategy = :fake_strategy }
+      .to raise_error KeyError
   end
 end


### PR DESCRIPTION
**What**
Updates JunkDrawer::Notifier to accept any arbitrary class as a
strategy, as long as the class implements a call method.

**Why**
Currently, there are only a few pre-defined strategies that the Notifier
can be configured with. This addition provides a lot more flexibility,
allowing users of the gem to define their own custom strategies on the
fly.

[ch14664](https://app.clubhouse.io/informedk12/story/14664/update-junkdrawer-notifier-to-accept-a-callable-strategy)