### PR TITLE
Upgrade to Active Record & Active Support 6.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', '~> 5.1.0'
-gem 'activesupport', '~> 5.1.0'
+gem 'activerecord', '~> 6.0.0'
+gem 'activesupport', '~> 6.0.0'
 gem 'hstore_accessor', '~> 1.1.1'
 gem 'jsonb_accessor', '~> 1.0.0'


### PR DESCRIPTION
**What**
Upgrades Active Record and Active Support to version 6.0.x.

**Why**
There are unpatched vulnerablities on the version we were using and
while they are fixed in 5.2.4.5 we might as well upgrade to the current
major release.