### PR TITLE
Rails: use changes_applied on bulk update

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -15,7 +15,7 @@ module JunkDrawer
       changed_attributes = extract_changed_attributes(unique_objects)
       query = build_query_for(unique_objects, changed_attributes)
       connection.execute(query)
-      objects.each(&:clear_changes_information)
+      objects.each(&:changes_applied)
     end
 
   private

--- a/lib/junk_drawer/version.rb
+++ b/lib/junk_drawer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JunkDrawer
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
     expect(models.any?(&:changed?)).to be false
   end
 
+  it 'stores previous change information on records' do
+    models.first.boolean_value = true
+
+    expect { BulkUpdatableModel.bulk_update(models) }
+      .to change { models.first.previous_changes['boolean_value'] }
+      .from(nil).to([nil, true])
+  end
+
   context 'when there are multiple references to the same object' do
     let(:model) { models.first }
     let(:model_copy_1) { BulkUpdatableModel.find(model.id) }


### PR DESCRIPTION
**What**

This updates `BulkUpdatable` to use `changes_applied` rather than
`clear_changes_information`.

**Why**

`changes_applied` is what `ActiveRecord` uses internally when a model is
saved. It takes the current changes and tracks them as previous changes
so that you can see what changed even after a model has been saved.
Libraries like `CarrierWave` rely on this to figure out which records
need to have corresponding files removed/updated after a save. On the
other hand, `clear_changes_information` clears *all* information about
changes, which makes it impossible to figure out what changed.
