### PR TITLE
Upgrades: remove Ruby versions 2.4, 2.5 from build 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gems
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.6, 2.7]
         postgres: [10, 11, 12, 13, 14]
         rails: ['5.0']
     name: Ruby ${{ matrix.ruby }} x Postgres ${{ matrix.postgres }} x Rails ${{ matrix.rails }}


### PR DESCRIPTION
**Why**

This should allow us to upgrade Rubocop, which should then allow us to
add newer Ruby versions.