### PR TITLE
Upgrades: update tested Rails/Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,9 +13,9 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gems
     strategy:
       matrix:
-        ruby: [2.6, 2.7]
-        postgres: [10, 11, 12, 13, 14]
-        rails: ['5.0']
+        ruby: ['3.0', '3.1']
+        postgres: [12, 13, 14]
+        rails: ['7.0']
     name: Ruby ${{ matrix.ruby }} x Postgres ${{ matrix.postgres }} x Rails ${{ matrix.rails }}
 
     services:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'activerecord', '~> 5.2.0'
-gem 'activesupport', '~> 5.2.0'
-gem 'jsonb_accessor', '~> 1.3.6'

--- a/gemfiles/rails_5.0.gems
+++ b/gemfiles/rails_5.0.gems
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.0.0'
-gem 'activesupport', '~> 5.0.0'
-gem 'jsonb_accessor', '~> 1.0.0'

--- a/gemfiles/rails_7.0.gems
+++ b/gemfiles/rails_7.0.gems
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 7.0.0'
+gem 'activesupport', '~> 7.0.0'
+gem 'jsonb_accessor', '~> 1.3'
+gem 'pg', '~> 1.4'

--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
-  spec.add_development_dependency 'pg', '~> 0.20'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'pry-byebug', '~> 3.6.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Leaving off Ruby 3.2 for the moment as it will likely break.

**Notes**

I removed the `pg` gem from the `gemspec` file, as that version is not
compatible with Ruby 3. I moved it to `rails_7.0.gems` so it can be
managed alongside the Rails dependencies.