### PR TITLE
Upgrades: add Ruby 3.2 support 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gems
     strategy:
       matrix:
-        ruby: ['3.0', '3.1']
+        ruby: ['3.0', '3.1', '3.2']
         postgres: [12, 13, 14]
         rails: ['7.0']
     name: Ruby ${{ matrix.ruby }} x Postgres ${{ matrix.postgres }} x Rails ${{ matrix.rails }}

--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency 'ruby2_keywords', '~> 0.0.2'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'

--- a/lib/junk_drawer/callable.rb
+++ b/lib/junk_drawer/callable.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby2_keywords'
-
 module JunkDrawer
   # error to be thrown by Callable
   class CallableError < StandardError
@@ -21,8 +19,8 @@ module JunkDrawer
     # an instance. It also causes an error to be raised if a public instance
     # method is defined with a name other than `call`
     module ClassMethods
-      ruby2_keywords def call(*args, &block)
-        new.(*args, &block)
+      def call(*args, **kwargs, &block)
+        new.(*args, **kwargs, &block)
       end
 
       def to_proc

--- a/lib/junk_drawer/notifier.rb
+++ b/lib/junk_drawer/notifier.rb
@@ -27,8 +27,8 @@ module JunkDrawer
       null: NullStrategy,
     }.freeze
 
-    def call(*args)
-      self.class.strategy.(*args)
+    def call(*args, **kwargs)
+      self.class.strategy.(*args, **kwargs)
     end
 
   end

--- a/spec/junk_drawer/notifier_spec.rb
+++ b/spec/junk_drawer/notifier_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe JunkDrawer::Notifier, '#call' do
 
   it 'calls the configured pre-defined notifier with the given arguments' do
     JunkDrawer::Notifier.strategy = :raise
-    strategy = JunkDrawer::Notifier::RaiseStrategy
-    expect { notifier.('foo', 'bar', 'butts') }
-      .to invoke(:call).on(strategy).with('foo', 'bar', 'butts')
+    expected_message = 'my message, context: {:wat=>"butts"}'
+
+    expect { notifier.('my message', wat: 'butts') }
+      .to raise_error(JunkDrawer::NotifierError, expected_message)
   end
 
   it 'calls the configured callable notifier with the given arguments' do


### PR DESCRIPTION
This fixes a couple of issues around keyword arguments. When there is a
keyword argument passed it would raise an error:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
```