### PR TITLE
BulkUpdatable: Do not unecessarily update id

### DIFF
--- a/lib/junk_drawer/version.rb
+++ b/lib/junk_drawer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JunkDrawer
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
The last change inadvertantly started setting `id = temp_table.id`.
Previously this was not the case and it is unecessary to do.


**Before:**

without prepared statements
```
UPDATE with_model_bulk_updatable_models_33097_4240 SET "id" = tmp_table."id", "string_value" = tmp_table."string_value", "updated_at" = tmp_table."updated_at" FROM (VALUES (1, 'thing_0'::character varying, '2023-05-19 00:22:02.382888'::timestamp(6) without time zone), (2, 'thing_1'::character varying, '2023-05-19 00:22:02.382888'::timestamp(6) without time zone)) AS tmp_table(id, string_value, updated_at) WHERE with_model_bulk_updatable_models_33097_4240.id = tmp_table.id
```

with prepared statements
```
UPDATE with_model_bulk_updatable_models_33097_4240 SET "id" = tmp_table."id", "string_value" = tmp_table."string_value", "updated_at" = tmp_table."updated_at" FROM (VALUES ($1::bigint, $2::character varying, $3::timestamp(6) without time zone), ($4::bigint, $5::character varying, $6::timestamp(6) without time zone)) AS tmp_table(id, string_value, updated_at) WHERE with_model_bulk_updatable_models_33097_4240.id = tmp_table.id  [["id", 1], ["string_value", "thing_0"], ["updated_at", "2023-05-19 00:22:02.419593"], ["id", 2], ["string_value", "thing_1"], ["updated_at", "2023-05-19 00:22:02.419593"]]
```

**After:**

without prepared statements
```
UPDATE with_model_bulk_updatable_models_32736_4240 SET "string_value" = tmp_table."string_value", "updated_at" = tmp_table."updated_at" FROM (VALUES (1, 'thing_0'::character varying, '2023-05-19 00:21:20.838060'::timestamp(6) without time zone), (2, 'thing_1'::character varying, '2023-05-19 00:21:20.838060'::timestamp(6) without time zone)) AS tmp_table(id, string_value, updated_at) WHERE with_model_bulk_updatable_models_32736_4240.id = tmp_table.id
```

with prepared statements
```
UPDATE with_model_bulk_updatable_models_32736_4240 SET "string_value" = tmp_table."string_value", "updated_at" = tmp_table."updated_at" FROM (VALUES ($1::bigint, $2::character varying, $3::timestamp(6) without time zone), ($4::bigint, $5::character varying, $6::timestamp(6) without time zone)) AS tmp_table(id, string_value, updated_at) WHERE with_model_bulk_updatable_models_32736_4240.id = tmp_table.id  [["id", 1], ["string_value", "thing_0"], ["updated_at", "2023-05-19 00:21:20.803342"], ["id", 2], ["string_value", "thing_1"], ["updated_at", "2023-05-19 00:21:20.803342"]]
```
