### PR TITLE
BulkUpdatable: Fix exceeding max allowable bind parameters

### DIFF
--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -27,7 +27,7 @@ module JunkDrawer
       changed_attributes = extract_changed_attributes(unique_objects)
       attributes = ['id'] + changed_attributes
 
-      unique_objects.each_slice(batch_size(changed_attributes)) do |batch|
+      unique_objects.each_slice(batch_size(attributes)) do |batch|
         query = build_prepared_query_for(batch, attributes, changed_attributes)
         values = values_for_objects(batch, attributes)
         connection.exec_query(query, "#{name} Bulk Update", values, prepare: true)

--- a/lib/junk_drawer/version.rb
+++ b/lib/junk_drawer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JunkDrawer
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
 
     it 'splits the insert into batches based on max allowable bind params' do
       connection = TestModel.connection
-      allow(connection).to receive(:bind_params_length).and_return(3)
+      allow(connection).to receive(:bind_params_length).and_return(4)
       logger = double
       allow(logger).to receive(:debug?).and_return(true)
       allow(logger).to receive(:debug)


### PR DESCRIPTION
Fixes batch size calculation to prevent exceeding the maximum allowable
bind parameters in postgres. The id column was being left out of the
calculation.

```
ActiveRecord::StatementInvalid: PG::UnableToSend: number of parameters must be between 0 and 65535
```
